### PR TITLE
update readme and comments to standard design

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Below, you'll find the build procedure. For more comprehensive instructions, you
 2. Edit `main.js` and set the value of `launchDarklyEnvironmentId` to your LaunchDarkly client-side ID.
 
 ```
-const launchDarklyEnvironmentId = '5e44ab7d09107307fa78bd09';
+const launchDarklyEnvironmentId = 'myClientSideID';
 ```
 
 3. Install dependencies: `npm install`.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
-## LaunchDarkly Sample Electron Application 
+## LaunchDarkly sample Electron application 
 
-We've built a simple Electron application that demonstrates how LaunchDarkly's SDK works. 
+We've built a simple Electron application that demonstrates how LaunchDarkly's SDK works.
+
+Below, you'll find the build procedure. For more comprehensive instructions, you can visit your [Quickstart page](https://app.launchdarkly.com/quickstart#/) or the [Electron SDK reference guide](https://docs.launchdarkly.com/sdk/client-side/electron).
 
 ### Build instructions 
 
-1. Clone this repository: `git clone https://github.com/launchdarkly/hello-electron.git`
-2. Go into the `hello-electron` directory.
-3. If you want the application to display your own feature flags, instead of our example flags, edit `main.js` to set `launchDarklyEnvironmentId` to the client-side ID for your LaunchDarkly environment (shown in [Account Settings](https://app.launchdarkly.com/settings/projects)). (Note that your flags will only be available if you have checked the "Make this flag available to client-side SDKs" box in the feature flag settings.)
-4. Install dependencies: `npm install`
-5. Start the application: `npm start`
+1. In LaunchDarkly, make sure you have at least one feature flag. For each flag, check the "Make this flag available to client-side SDKs" box in the flag's **Settings** tab.
+2. Edit `main.js` and set the value of `launchDarklyEnvironmentId` to your LaunchDarkly client-side ID.
 
-### More information
+```
+const launchDarklyEnvironmentId = '5e44ab7d09107307fa78bd09';
+```
 
-- [Electron SDK Reference](https://docs.launchdarkly.com/v2.0/docs/electron-sdk-reference)
+3. Install dependencies: `npm install`.
+4. Start the application: `npm start`.
+
+The application displays a table of flag keys and flag values for the example user.

--- a/main.js
+++ b/main.js
@@ -17,12 +17,14 @@ const app = electron.app;
 
 let launchDarklyMainProcessClient;
 
-// Put the client-side ID for your LaunchDarkly environment here. The default value below will
-// still work, but it's for a demo environment where you would not be able to modify the flags.
-const launchDarklyEnvironmentId = '5c0727b6abf23c53a840a9ed';
+// Set launchDarklyEnvironmentId to your LaunchDarkly client-side ID.
+const launchDarklyEnvironmentId = '';
 
+// Set up the user properties. This user should appear on your LaunchDarkly
+// users dashboard soon after you run the demo.
 const launchDarklyUser = {
-  key: 'test-user-key'
+  key: 'example-user-key',
+  name: 'Sandy'
 };
 
 const launchDarklyOptions = {

--- a/main.js
+++ b/main.js
@@ -5,7 +5,7 @@
 // and displays them in a window. It uses streaming mode so that if any flag is changed on
 // the LaunchDarkly dashboard, the on-screen value will be updated.
 //
-// The application structure based on the Electron Quick Start Guide: http://electron.atom.io/docs/tutorial/quick-start
+// The application structure is based on the Electron Quick Start Guide: http://electron.atom.io/docs/tutorial/quick-start.
 //
 
 const electron = require('electron');

--- a/main.js
+++ b/main.js
@@ -56,5 +56,12 @@ app.on('ready', () => {
 
 // Quit when all windows are closed.
 app.on('window-all-closed', function () {
+  // Here we ensure that the SDK shuts down cleanly and has a chance to
+  // deliver analytics events to LaunchDarkly before the program exits.
+  // If analytics events are not delivered, the user properties and flag
+  // usage statistics will not appear on your dashboard. In a normal
+  // long-running application, the SDK would continue running and events
+  // would be delivered automatically in the background.
+  launchDarklyMainProcessClient.close();
   app.quit();
 });

--- a/window.js
+++ b/window.js
@@ -6,7 +6,7 @@ const ldclient = require('ldclient-electron');
 
 const launchDarklyBrowserClient = ldclient.initializeInRenderer();
 
-// Wait for the client to be initialized. 
+// Wait for the client to be initialized.
 launchDarklyBrowserClient.on('ready', () => {
   $('#ld-status').text('Loaded feature flags.');
 

--- a/window.js
+++ b/window.js
@@ -6,7 +6,7 @@ const ldclient = require('ldclient-electron');
 
 const launchDarklyBrowserClient = ldclient.initializeInRenderer();
 
-// Wait for the client to be initialized.
+// Wait for the client to be initialized. 
 launchDarklyBrowserClient.on('ready', () => {
   $('#ld-status').text('Loaded feature flags.');
 


### PR DESCRIPTION
[SC-154165](https://app.shortcut.com/launchdarkly/story/154165): After receiving some feedback that it'd be helpful if the Hello apps were more standardized, Docs team is working on updating them to [match the spec](https://launchdarkly.atlassian.net/wiki/spaces/ENG/pages/1499562073/SDK+hello+world).

As the [Audit document](https://launchdarkly.atlassian.net/wiki/spaces/ENG/pages/1499628469/Auditing+SDK+hello+world+apps) notes, this sample app is written pretty differently, so I've just added in more standard comments and variable values where it seems relevant.